### PR TITLE
fix: default value for

### DIFF
--- a/src/decoders/grades-overview.ts
+++ b/src/decoders/grades-overview.ts
@@ -3,7 +3,7 @@ import { decodeGradeValue } from "./grade-value";
 
 export const buildOverview = (data: any): GradesOverview => {
   const overview: GradesOverview = {};
-  const outOf = data.parametrage.moyenneSur;
+  const outOf = data.parametrage.moyenneSur || 20;
   const showStudentAverage = data.parametrage.moyenneGenerale;
   const showYearlyPeriod = data.parametrage.notePeriodeAnnuelle;
 


### PR DESCRIPTION
fix: set a default value for `data.parametrage.moyenneSur` because it… can be undefined

# Description

In `grades-overview.ts`, the `outOf` variable has now a default value `20` if `data.parametrage.moyenneSur` is undefined.

Fixes #15 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested using an Ecoledirecte account (`examples/student-grades.ts`)
- [x] Tested using an Ecoledirecte account, which grades parameters have undefined `moyenneSur` (`examples/student-grades.ts`)

**Test Configuration**:

- Node 18.19.0
- PNPM 9.9.0
- Bun 1.1.29

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

